### PR TITLE
Fixed issue with broken callback. Moved testing to use stubbing

### DIFF
--- a/lib/sidekiq/simple_workflow.rb
+++ b/lib/sidekiq/simple_workflow.rb
@@ -35,7 +35,7 @@ module Sidekiq
         end
       end
       if defined?(Sidekiq::Testing) && Sidekiq::Testing.enabled?
-        send("step_2_batch", RSpec::Sidekiq::NullStatus.new, args)
+        step_batch.status.join
       end
       step_batch
     end
@@ -51,7 +51,7 @@ module Sidekiq
             next_step_method = step_method_name(step_number + 1)
             if respond_to? next_step_method
 
-              callback = "#{self.class}##{next_step_method}"
+              callback = callback_method(step_number + 1)
               step_batch.on(:complete, callback, options)
             end
             step_batch.jobs do
@@ -60,7 +60,7 @@ module Sidekiq
             end
           end
           if defined?(Sidekiq::Testing) && Sidekiq::Testing.enabled?
-            send("step_#{step_number + 1}_batch", RSpec::Sidekiq::NullStatus.new, options)
+            step_batch.status.join
           end
           step_batch
         end


### PR DESCRIPTION
This PR fixes #2 .  Essentially the code for steps 2-10 were creating a callback to a method that did not exist.  The unit specs did not catch this because we were initially calling each workflow step individually.  Subsequently we were directly calling the callback and masking the bug.

- [x] Corrected an issue where the callback was referencing a non existent method
- [x] Changed the test code to use `batch.status.join` instead of directly calling the callback
- [x] Moved tests to use stubbing since `batch.status.join` drains the queue.